### PR TITLE
Support passing array of commands into given method

### DIFF
--- a/git-packages.json
+++ b/git-packages.json
@@ -1,10 +1,1 @@
-{
-  "space:base": {
-    "git": "https://github.com/meteor-space/base.git",
-    "version": "cc23eb17c6742697d3f6c5e4886a5617daadce8c"
-  },
-  "space:testing": {
-    "git": "https://github.com/meteor-space/testing.git",
-    "version": "f964632b5ff87a72fe83a75d6c65ad967dbaeed4"
-  }
-}
+{}

--- a/package.js
+++ b/package.js
@@ -26,18 +26,21 @@ Package.onUse(function(api) {
 
 });
 
-//Package.onTest(function(api) {
-//
-//  api.use([
-//    'coffeescript',
-//    'ecmascript',
-//    'check',
-//    'space:base@4.1.0',
-//    'space:testing@3.0.1',
-//    'practicalmeteor:munit@2.1.5'
-//  ]);
-//
-//  api.addFiles([
-//  ], 'server');
-//
-//});
+Package.onTest(function(api) {
+
+  api.use([
+    'coffeescript',
+    'ecmascript',
+    'check',
+    'space:base@4.1.1',
+    'space:testing@3.0.1',
+    'space:testing-event-sourcing@3.0.0',
+    'space:domain@0.2.1',
+    'practicalmeteor:munit@2.1.5'
+  ]);
+
+  api.addFiles([
+    //'tests/aggregate-test.unit.js'
+  ], 'server');
+
+});

--- a/package.js
+++ b/package.js
@@ -15,7 +15,7 @@ Package.onUse(function(api) {
     'ecmascript',
     'check',
     'underscore',
-    'space:base@4.1.0',
+    'space:base@4.1.1',
     'practicalmeteor:munit@2.1.5'
   ]);
 

--- a/package.js
+++ b/package.js
@@ -40,7 +40,7 @@ Package.onTest(function(api) {
   ]);
 
   api.addFiles([
-    //'tests/aggregate-test.unit.js'
+    'tests/aggregate-test.unit.js'
   ], 'server');
 
 });

--- a/source/aggregates-bdd-api.coffee
+++ b/source/aggregates-bdd-api.coffee
@@ -1,9 +1,9 @@
 Space.Module.registerBddApi (app, systemUnderTest) ->
   if !Space.eventSourcing? then return
   if isSubclassOf(systemUnderTest, Space.eventSourcing.Aggregate)
-    return new AggregateTest(app)
+    return new Space.AggregateTest(app)
 
-class AggregateTest
+class Space.AggregateTest
 
   constructor: (@_app) ->
     @_app.reset()

--- a/source/aggregates-bdd-api.coffee
+++ b/source/aggregates-bdd-api.coffee
@@ -26,19 +26,15 @@ class AggregateTest
     commands = []
     events = []
     if !_.isArray(data)
-      if data instanceof Space.messaging.Event
-        events.push(data);
-      if data instanceof Space.messaging.Command
-        commands.push(data)
-    else if _.isArray(data)
-      _.each(data, (message) =>
-        if message instanceof Space.messaging.Command
-          commands.push(message)
-        else if message instanceof Space.messaging.Event
-          events.push(message)
-        else
-          throw new Error 'Invalid item in given array'
-      )
+      data = [data]
+    _.each(data, (message) =>
+      if message instanceof Space.messaging.Command
+        commands.push(message)
+      else if message instanceof Space.messaging.Event
+        events.push(message)
+      else
+        throw new Error 'Invalid item in given array'
+    )
     if events.length > 0
       # We have to add a commit to setup state
       changes = { events: events, commands: [] }

--- a/tests/aggregate-test.unit.js
+++ b/tests/aggregate-test.unit.js
@@ -1,0 +1,173 @@
+
+describe('AggregateTest', function() {
+
+  const MyCommand = Space.domain.Command.extend('AggregateTest.MyCommand', {});
+  const MyEvent = Space.domain.Event.extend('AggregateTest.MyEvent', {});
+  const MyApplication = Space.Application.define('AggregateTest.MyApplication', {
+    configuration: {
+      appId: 'AggregateTest.MyApplication'
+    }
+  });
+
+  describe('given', function() {
+
+    beforeEach(function() {
+      this.commitStoreMock = sinon.mock({
+        add() {}
+      });
+      this.eventBusMock = sinon.mock({
+        onPublish() {}
+      });
+      const commandBusStub = sinon.stub();
+      const app = new MyApplication({
+        eventBus: this.eventBusMock,
+        commandBus: commandBusStub
+      });
+      app.injector.map('Space.eventSourcing.CommitStore').to(this.commitStoreMock.object);
+      app.injector.map('Space.messaging.EventBus').to(this.eventBusMock.object);
+      app.injector.map('Space.messaging.CommandBus').to(commandBusStub);
+
+      this.aggregateTest = new AggregateTest(app);
+    });
+
+    it('can be called without data', function() {
+      const callWithoutData = () => {
+        this.aggregateTest.given()
+      };
+      expect(callWithoutData).to.not.throw(Error);
+    });
+
+    it('adds a single command to the run queue to establish state before when messages', function() {
+      const commandInstance = new MyCommand({
+        targetId: new Guid()
+      });
+      this.aggregateTest.given(commandInstance);
+      expect(this.aggregateTest._messages).to.matchArrayOfStructs([commandInstance])
+    });
+
+    it('adds a single event to the commit store in a commit object', function() {
+      const event = new MyEvent({
+        sourceId: new Guid()
+      });
+      this.commitStoreMock.expects("add").once();
+      this.aggregateTest.given(event);
+      this.commitStoreMock.verify();
+    });
+
+    it('adds an array of commands to the run queue to establish state before when messages', function() {
+      const commands = [
+        new MyCommand({
+          targetId: new Guid()
+        }),
+        new MyCommand({
+          targetId: new Guid()
+        })
+      ];
+      this.aggregateTest.given(commands);
+      expect(this.aggregateTest._messages).to.matchArrayOfStructs(commands)
+    });
+
+    it('adds an array of events to the commit store in a commit object', function() {
+      const aggregateId = new Guid();
+      const events = [
+        new MyEvent({
+          sourceId: aggregateId
+        }),
+        new MyEvent({
+          sourceId: aggregateId
+        })
+      ];
+      this.commitStoreMock.expects("add").once();
+      this.aggregateTest.given(events);
+      this.commitStoreMock.verify();
+    });
+
+  });
+
+  describe('when', function() {
+
+    it('adds a single event to the run queue with existing items', function() {
+      const whenCommand = new MyCommand({
+        targetId: new Guid()
+      });
+      this.aggregateTest._messages.push(whenCommand);
+      const event = new MyEvent({
+        sourceId: new Guid()
+      });
+      this.aggregateTest.when(event);
+      expect(this.aggregateTest._messages).to.matchArrayOfStructs([whenCommand, event])
+    });
+
+    it('adds a single command to the run queue', function() {
+      const command = new MyCommand({
+        targetId: new Guid()
+      });
+      this.aggregateTest.when(command);
+      expect(this.aggregateTest._messages).to.matchArrayOfStructs([command])
+    });
+
+    it('adds an array of commands to the run queue', function() {
+      const commands = [
+        new MyCommand({
+          targetId: new Guid()
+        }),
+        new MyCommand({
+          targetId: new Guid()
+        })
+      ];
+      this.aggregateTest.when(commands);
+      expect(this.aggregateTest._messages).to.matchArrayOfStructs(commands)
+    });
+
+    it('adds an array of events to the run queue', function() {
+      const events = [
+        new MyEvent({
+          sourceId: new Guid()
+        }),
+        new MyEvent({
+          sourceId: new Guid()
+        })
+      ];
+      this.aggregateTest.when(events);
+      expect(this.aggregateTest._messages).to.matchArrayOfStructs(events)
+    });
+
+  });
+
+  describe('expect', function() {
+
+    it('can take a function that returns an array of events, running the initialized test as a result', function() {
+      this.aggregateTest._run = sinon.spy();
+      const events = [
+        new MyEvent({
+          sourceId: new Guid()
+        }),
+        new MyEvent({
+          sourceId: new Guid()
+        })
+      ];
+      this.aggregateTest.expect(function() {
+        return events
+      });
+      expect(this.aggregateTest._expectedEvents).to.matchArrayOfStructs(events);
+      expect(this.aggregateTest._run).to.have.been.called;
+    });
+
+    it('can take an array of events, running the initialized test as a result', function() {
+      this.aggregateTest._run = sinon.spy();
+      const events = [
+        new MyEvent({
+          sourceId: new Guid()
+        }),
+        new MyEvent({
+          sourceId: new Guid()
+        })
+      ];
+      this.aggregateTest.expect(events);
+      expect(this.aggregateTest._expectedEvents).to.matchArrayOfStructs(events);
+      expect(this.aggregateTest._run).to.have.been.called;
+    });
+
+  });
+
+});

--- a/tests/aggregate-test.unit.js
+++ b/tests/aggregate-test.unit.js
@@ -27,7 +27,7 @@ describe('AggregateTest', function() {
       app.injector.map('Space.messaging.EventBus').to(this.eventBusMock.object);
       app.injector.map('Space.messaging.CommandBus').to(commandBusStub);
 
-      this.aggregateTest = new AggregateTest(app);
+      this.aggregateTest = new Space.AggregateTest(app);
     });
 
     it('can be called without data', function() {


### PR DESCRIPTION
This change makes it possible to test more complex domain models by allowing multiple commands to setup state.  I've added a unit test for `AggregateTest` but since the symbol is not exported I'm not sure how to gain access without attaching it to the global scope, so have left it commented out.

<img width="1023" alt="screen shot 2016-02-14 at 19 50 56" src="https://cloud.githubusercontent.com/assets/303881/13032788/58a19908-d354-11e5-9ec9-f69a988718e1.png">
